### PR TITLE
Adds missing mapping of the alphanumeric minus key for firefox

### DIFF
--- a/vendor/assets/javascripts/spiceHTML5/utils.js
+++ b/vendor/assets/javascripts/spiceHTML5/utils.js
@@ -209,6 +209,7 @@ common_scanmap[93]                 = 0xE05D; //KEY_Menu
 /* Firefox/Mozilla codes */
 var firefox_scanmap = [];
 firefox_scanmap[109]                = KEY_Minus;
+firefox_scanmap[173]                = KEY_Minus;
 firefox_scanmap[61]                 = KEY_Equal;
 firefox_scanmap[59]                 = KEY_SemiColon;
 


### PR DESCRIPTION
Fixes error message "no map for 173" when pressing the minus key with firefox 26.0 
